### PR TITLE
Update apostrophe drawings

### DIFF
--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -318,8 +318,12 @@ parse_config:
     SQT:
       tap: "'"
       shifted: '"'
-    APOSTROPHE: <
-    APOS: .
+    APOSTROPHE: 
+      tap: "'"
+      shifted: '"'
+    APOS: 
+      tap: "'"
+      shifted: '"'
     DOUBLE_QUOTES: '"'
     DQT: '"'
 


### PR DESCRIPTION
Updates the drawer config to generate the svg with `'` for tapping and `"` for shifted press for `APOSTROPHE` and `APOS` mappings. Following the keycode list here https://zmk.dev/docs/keymaps/list-of-keycodes#symbols--punctuation

From  

![img1](https://github.com/user-attachments/assets/12984073-b552-48ad-93b8-c859a987393c)


To  

![img2](https://github.com/user-attachments/assets/45382199-ee45-4305-adb1-cc5def7879aa)
